### PR TITLE
Fix order of fields in .js.map 

### DIFF
--- a/change/azure-devops-symbols-webpack-plugin-4cdbcd3d-c282-4158-9c58-9d8b89ca40d8.json
+++ b/change/azure-devops-symbols-webpack-plugin-4cdbcd3d-c282-4158-9c58-9d8b89ca40d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Use the shared logic to make sure 'file' and 'soucemap client id' fields are in the beginning of the file to optimize the symbol upload costs",
+  "packageName": "azure-devops-symbols-webpack-plugin",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -2,7 +2,7 @@
 import * as webpackTypes from "webpack";
 import { ConcatSource, Source } from "webpack-sources";
 import * as path from "path";
-import { computeSourceMapUrlLine, sourceMapClientKeyField } from "azure-devops-symbols-sourcemap";
+import { computeSourceMapUrlLine, setClientKeyOnSourceMap } from "azure-devops-symbols-sourcemap";
 
 const pluginName = "AzureDevOpsSymbolsPlugin";
 
@@ -73,7 +73,7 @@ export class AzureDevOpsSymbolsPlugin
                                     const clientKey = <string>hash.digest("hex");
                             
                                     // Add the sourcemap client id field to the sourcemap json object.
-                                    (<any>sourceMap)[sourceMapClientKeyField] = clientKey;
+                                    setClientKeyOnSourceMap(clientKey, sourceMap);
 
                                     const sourceMapFileName = path.basename(file);
                                     const sourceMapLineToAppend = computeSourceMapUrlLine(this.organization, clientKey, sourceMapFileName);


### PR DESCRIPTION
Use the shared logic to make sure that the 'file' and 'x_microsoft_symbol_client_key' fields are early in the JSON file to reduce the ammount of content that the symbol uploader will have to parse through.