### PR TITLE
Enable silent option/mode for CLI and webpack plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ module.exports = {
         ...
 
         new AzureDevOpsSymbolsPlugin({
-            organization: "contoso"
+            organization: "contoso",
+            silent: true // to switch off diagnosic console logging
         })
     ],
     ...

--- a/change/azure-devops-symbols-sourcemap-5c15fa04-b2b3-4dab-9118-257e4159563b.json
+++ b/change/azure-devops-symbols-sourcemap-5c15fa04-b2b3-4dab-9118-257e4159563b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Enable silent option/mode for CLI and webpack plugins",
+  "packageName": "azure-devops-symbols-sourcemap",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/azure-devops-symbols-sourcemap-cli-abb0d17c-9a4f-425a-891c-fbd9fb27852c.json
+++ b/change/azure-devops-symbols-sourcemap-cli-abb0d17c-9a4f-425a-891c-fbd9fb27852c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Enable silent option/mode for CLI and webpack plugins",
+  "packageName": "azure-devops-symbols-sourcemap-cli",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/azure-devops-symbols-webpack-plugin-8e3f896a-e4db-4e9a-ac1a-4f52d7dfd0ec.json
+++ b/change/azure-devops-symbols-webpack-plugin-8e3f896a-e4db-4e9a-ac1a-4f52d7dfd0ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Enable silent option/mode for CLI and webpack plugins",
+  "packageName": "azure-devops-symbols-webpack-plugin",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/azure-devops-symbols-webpack4-plugin-93259f4e-040e-420f-a1eb-9e9fc4a6de69.json
+++ b/change/azure-devops-symbols-webpack4-plugin-93259f4e-040e-420f-a1eb-9e9fc4a6de69.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Enable silent option/mode for CLI and webpack plugins",
+  "packageName": "azure-devops-symbols-webpack4-plugin",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/sourcemap-cli/src/cli.ts
+++ b/packages/sourcemap-cli/src/cli.ts
@@ -31,10 +31,15 @@ const argv = yargs.options({
     describe: 'The hash algorithm to use of the original source file. Valid values are algorithms of https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm_options',
     default: 'sha256'
   },
+  silent: {
+    type: 'boolean',
+    describe: 'Switches off informational console logging',
+    default: false
+  }
 }).parseSync();
 
-async function run(directory: string, organization: string, globPattern: string, hashAlgo: string) : Promise<void>{
-  const jsMapFiles = glob.sync(globPattern, { cwd: directory } );
+async function run(directory: string, organization: string, globPattern: string, hashAlgo: string, silent: boolean) : Promise<void>{
+  const jsMapFiles = glob.sync(globPattern, { cwd: directory });
   
   if (jsMapFiles.length === 0) {
     fail(`No files found for pattern ${globPattern}`);
@@ -42,8 +47,10 @@ async function run(directory: string, organization: string, globPattern: string,
 
   for (var jsMapFile of jsMapFiles) {
     const jsMapFilePath = path.join(directory, jsMapFile);
-    console.log(`Indexing ${jsMapFilePath}`)
-    await indexJsMapFileAsync(organization, hashAlgo, jsMapFilePath);
+    if (!silent) {
+      console.log(`Indexing ${jsMapFilePath}`);
+    }
+    await indexJsMapFileAsync(organization, hashAlgo, jsMapFilePath, silent);
   }
 }
 
@@ -55,5 +62,5 @@ if (!fsExtra.pathExistsSync(argv.directory)) {
   fail(`Specified argument: 'folder' with value '${argv.directory}' does not exist.`);
 }
 
-run(argv.directory, argv.organization, argv.globPattern, argv.hashAlgo)
+run(argv.directory, argv.organization, argv.globPattern, argv.hashAlgo, argv.silent)
   .catch(err => fail(err));

--- a/packages/sourcemap/src/index.ts
+++ b/packages/sourcemap/src/index.ts
@@ -73,7 +73,7 @@ export async function indexJsMapFileAsync(organization: string, hashAlgo: string
     setClientKeyOnSourceMap(clientKey, sourceMap)
     await fsExtra.writeJSON(jsMapFile, sourceMap);
 
-    log(`    Updating source file ${sourceFilePath}`);    
+    log(`    Updating source file ${sourceFilePath}`);
     const sourceMapUrlComment = computeSourceMapUrlLine(organization, clientKey, path.basename(jsMapFile));
     await fsExtra.appendFile(sourceFilePath, sourceMapUrlComment);
 }

--- a/packages/sourcemap/src/index.ts
+++ b/packages/sourcemap/src/index.ts
@@ -48,7 +48,7 @@ function hashFile(path: string) : Promise<string> {
 export async function indexJsMapFileAsync(organization: string, hashAlgo: string, jsMapFile: string, silent?: boolean) : Promise<void> {
     const log = silent ? () => {} : console.log;
     
-    log(`Processing sourcemap file ${jsMapFile}`);
+    log(`Processing sourcemap file ${jsMapFile} for organization ${organization} with hash algorithm: ${hashAlgo}`);
 
     const sourceMap = await fsExtra.readJson(jsMapFile);
     if (!sourceMap.file) {

--- a/packages/sourcemap/src/index.ts
+++ b/packages/sourcemap/src/index.ts
@@ -45,8 +45,10 @@ function hashFile(path: string) : Promise<string> {
     );
 }
 
-export async function indexJsMapFileAsync(organization: string, hashAlgo: string, jsMapFile: string) : Promise<void> {
-    console.log(`Processing sourcemap file ${jsMapFile}`);
+export async function indexJsMapFileAsync(organization: string, hashAlgo: string, jsMapFile: string, silent?: boolean) : Promise<void> {
+    const log = silent ? () => {} : console.log;
+    
+    log(`Processing sourcemap file ${jsMapFile}`);
 
     const sourceMap = await fsExtra.readJson(jsMapFile);
     if (!sourceMap.file) {
@@ -67,11 +69,11 @@ export async function indexJsMapFileAsync(organization: string, hashAlgo: string
     }
 
     // Update the sourcemap file.
-    console.log(`    Updating sourcemap file with key ${clientKey}`);
+    log(`    Updating sourcemap file with key ${clientKey}`);
     setClientKeyOnSourceMap(clientKey, sourceMap)
     await fsExtra.writeJSON(jsMapFile, sourceMap);
 
-    console.log(`    Updating source file ${sourceFilePath}`);
+    log(`    Updating source file ${sourceFilePath}`);    
     const sourceMapUrlComment = computeSourceMapUrlLine(organization, clientKey, path.basename(jsMapFile));
     await fsExtra.appendFile(sourceFilePath, sourceMapUrlComment);
 }

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -13,16 +13,25 @@ export interface AzureDevOpsSymbolsPluginOptions {
   // Using the Edge AzureDevOps PersonalAccessToken route. In this case the 'sourceMappingURL' isn't appended, and users must add their ADO PAT in Edge DevTools
   // See https://blogs.windows.com/msedgedev/2022/04/12/retrieve-source-maps-securely-in-production-in-microsoft-edge-devtools/
   useEdgePAT?: boolean;
+  silent?: boolean;
 }
 
 export class AzureDevOpsSymbolsPlugin {
   organization: string = "<Organization>";
   useEdgePAT: boolean = false;
+  silent: boolean = false;
 
   constructor(options?: AzureDevOpsSymbolsPluginOptions) {
     if (options) {
       this.organization = options.organization;
       this.useEdgePAT = !!options.useEdgePAT;
+      this.silent = !!options.silent;
+    }
+  }
+
+  private log(...args: Parameters<Console["log"]>): void {
+    if (!this.silent) {
+      console.log(...args);
     }
   }
 
@@ -78,7 +87,7 @@ export class AzureDevOpsSymbolsPlugin {
                 asset.source.updateHash(hash);
                 const clientKey = <string>hash.digest("hex");
 
-                console.log(
+                this.log(
                   `Tagging sourcemap with ${clientKey} to ${asset.name}`
                 );
 
@@ -131,7 +140,7 @@ export class AzureDevOpsSymbolsPlugin {
               asset.info.related.sourceMapLineToAppend &&
               !this.useEdgePAT
             ) {
-              console.log(`Adding SourceMap comment to ${asset.name}`);
+              this.log(`Adding SourceMap comment to ${asset.name}`);
               const content = <string>asset.info.related.sourceMapLineToAppend;
 
               compilation.updateAsset(

--- a/packages/webpack4-plugin/src/plugin.ts
+++ b/packages/webpack4-plugin/src/plugin.ts
@@ -14,6 +14,7 @@ export interface AzureDevOpsSymbolsPluginOptions {
   // Using the Edge AzureDevOps PersonalAccessToken route. In this case the 'sourceMappingURL' isn't appended, and users must add their ADO PAT in Edge DevTools
   // See https://blogs.windows.com/msedgedev/2022/04/12/retrieve-source-maps-securely-in-production-in-microsoft-edge-devtools/
   useEdgePAT?: boolean;
+  silent?: boolean;
 }
 
 /**
@@ -22,11 +23,19 @@ export interface AzureDevOpsSymbolsPluginOptions {
 export class AzureDevOpsSymbolsPlugin {
   organization: string = "<Organization>";
   useEdgePAT: boolean = false;
+  silent: boolean = false;
 
   constructor(options?: AzureDevOpsSymbolsPluginOptions) {
     if (options) {
       this.organization = options.organization;
       this.useEdgePAT = !!options.useEdgePAT;
+      this.silent = !!options.silent;
+    }
+  }
+
+  private log(...args: Parameters<Console["log"]>): void {
+    if (!this.silent) {
+      console.log(...args);
     }
   }
 
@@ -38,7 +47,7 @@ export class AzureDevOpsSymbolsPlugin {
       <any>options.devtool === true ||
       !options.devtool.includes("source-map")
     ) {
-      console.log(
+      this.log(
         `${pluginName}: returning since there's no source-map devtool`
       );
       return;
@@ -86,7 +95,7 @@ export class AzureDevOpsSymbolsPlugin {
               asset.source.updateHash(hash);
               const clientKey = <string>hash.digest("hex");
 
-              console.log(
+              this.log(
                 `Tagging sourcemap with ${clientKey} to ${asset.name}`
               );
 


### PR DESCRIPTION
The webpack plugin logs verbose diagnostic information to the console. 
This is nice for troubleshooting but it creates unnecessary noise in logs when not.

This PR adds `--silent` flag to the CLI package and a `{ silent?: boolean }` option  to the webpack plugin packages to enable switching off the verbose logging in both scenarios.

Please approve and release new package versions.